### PR TITLE
[DM-16605] Customization of the Chronograf UI for SQuaSH - I

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ LDFLAGS=-ldflags "-s -X main.version=${VERSION} -X main.commit=${COMMIT}"
 BINARY=chronograf
 CTLBINARY=chronoctl
 
+IMAGE=lsstsqre/${BINARY}
+IMAGE_TAG=latest
+
 .DEFAULT_GOAL := all
 
 all: dep build
@@ -42,7 +45,8 @@ docker-${BINARY}: $(SOURCES)
 		./cmd/chronograf/main.go
 
 docker: dep assets docker-${BINARY}
-	docker build -t chronograf .
+	docker build -t ${IMAGE}:${IMAGE_TAG} .
+	docker push ${IMAGE}:${IMAGE_TAG}
 
 assets: .jssrc .bindata
 
@@ -57,7 +61,7 @@ server/swagger_gen.go: server/swagger.json
 
 canned/bin_gen.go: canned/*.json
 	go generate -x ./canned
-	
+
 protoboards/bin_gen.go: protoboards/*.json
 	go generate -x ./protoboards
 

--- a/ui/src/auth/Login.js
+++ b/ui/src/auth/Login.js
@@ -17,7 +17,12 @@ const Login = ({authData: {auth}}) => {
     <div>
       <Notifications />
       <SplashPage>
-        <h1 className="auth-text-logo">Chronograf</h1>
+        <h1>SQuaSH</h1>
+        <h4>A QC Service by LSST DM/SQuaRE</h4>
+        <p>
+        powered by
+        </p>
+        <h2>Chronograf</h2>
         <p>
           <strong>{VERSION}</strong> / Time-Series Data Visualization
         </p>

--- a/ui/src/shared/components/SplashPage.tsx
+++ b/ui/src/shared/components/SplashPage.tsx
@@ -7,7 +7,6 @@ interface Props {
 const SplashPage: SFC<Props> = ({children}) => (
   <div className="auth-page">
     <div className="auth-box">
-      <div className="auth-logo" />
       {children}
     </div>
     <p className="auth-credits">

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -424,7 +424,7 @@ export const PREDEFINED_TEMP_VARS = [
 export const INITIAL_GROUP_BY_TIME = '10s'
 export const AUTO_GROUP_BY = 'auto'
 
-export const DEFAULT_HOME_PAGE = 'status'
+export const DEFAULT_HOME_PAGE = 'dashboards'
 
 export const STATUS_PAGE_ROW_COUNT = 10 // TODO: calculate based on actual Status Page cells
 export const PAGE_HEADER_HEIGHT = 60 // TODO: get this dynamically to ensure longevity

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -83,14 +83,6 @@ class SideNav extends PureComponent<Props> {
         </NavBlock>
         </Authorized>
         <NavBlock
-          highlightWhen={['data-explorer']}
-          icon="graphline-2"
-          link={dataExplorerLink}
-          location={location}
-        >
-          <NavHeader link={dataExplorerLink} title="Explore" />
-        </NavBlock>
-        <NavBlock
           highlightWhen={['dashboards']}
           icon="dash-j"
           link={`${sourcePrefix}/dashboards`}
@@ -98,7 +90,15 @@ class SideNav extends PureComponent<Props> {
         >
           <NavHeader link={`${sourcePrefix}/dashboards`} title="Dashboards" />
         </NavBlock>
-        <Authorized
+        <NavBlock
+          highlightWhen={['data-explorer']}
+          icon="graphline-2"
+          link={dataExplorerLink}
+          location={location}
+        >
+          <NavHeader link={dataExplorerLink} title="Explore" />
+        </NavBlock>
+      <Authorized
           requiredRole={EDITOR_ROLE}
           replaceWithIfNotUsingAuth={}
           >
@@ -117,7 +117,9 @@ class SideNav extends PureComponent<Props> {
           </NavListItem>
         </NavBlock>
       </Authorized>
-
+      <Authorized
+        requiredRole={ADMIN_ROLE}
+        replaceWithIfNotUsingAuth={
         <NavBlock
           highlightWhen={['logs']}
           icon="wood"
@@ -126,7 +128,17 @@ class SideNav extends PureComponent<Props> {
         >
           <NavHeader link={'/logs'} title="Log Viewer" />
         </NavBlock>
-
+        }
+      >
+        <NavBlock
+          highlightWhen={['logs']}
+          icon="wood"
+          link="/logs"
+          location={location}
+        >
+          <NavHeader link={'/logs'} title="Log Viewer" />
+        </NavBlock>
+      </Authorized>
         <Authorized
           requiredRole={ADMIN_ROLE}
           replaceWithIfNotUsingAuth={
@@ -139,18 +151,6 @@ class SideNav extends PureComponent<Props> {
               <NavHeader
                 link={`${sourcePrefix}/admin-influxdb/databases`}
                 title="InfluxDB Admin"
-              />
-            </NavBlock>
-
-            <NavBlock
-              highlightWhen={['manage-sources', 'kapacitors']}
-              icon="wrench"
-              link={`${sourcePrefix}/manage-sources`}
-              location={location}
-            >
-              <NavHeader
-                link={`${sourcePrefix}/manage-sources`}
-                title="Configuration"
               />
             </NavBlock>
           }
@@ -174,6 +174,23 @@ class SideNav extends PureComponent<Props> {
               InfluxDB
             </NavListItem>
           </NavBlock>
+        </Authorized>
+        <Authorized
+          requiredRole={ADMIN_ROLE}
+          replaceWithIfNotUsingAuth={
+          <NavBlock
+            highlightWhen={['manage-sources', 'kapacitors']}
+            icon="wrench"
+            link={`${sourcePrefix}/manage-sources`}
+            location={location}
+          >
+            <NavHeader
+              link={`${sourcePrefix}/manage-sources`}
+              title="Configuration"
+            />
+          </NavBlock>
+        }
+        >
         <NavBlock
           highlightWhen={['manage-sources', 'kapacitors']}
           icon="wrench"

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -4,6 +4,7 @@ import {withRouter, Link} from 'react-router'
 import {connect} from 'react-redux'
 
 import Authorized, {ADMIN_ROLE} from 'src/auth/Authorized'
+import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
 
 import UserNavBlock from 'src/side_nav/components/UserNavBlock'
 
@@ -68,6 +69,10 @@ class SideNav extends PureComponent<Props> {
             <span className="sidebar--icon icon cubo-uniform" />
           </Link>
         </div>
+        <Authorized
+        requiredRole={ADMIN_ROLE}
+        replaceWithIfNotUsingAuth={}
+        >
         <NavBlock
           highlightWhen={['hosts']}
           icon="eye"
@@ -76,6 +81,7 @@ class SideNav extends PureComponent<Props> {
         >
           <NavHeader link={`${sourcePrefix}/hosts`} title="Host List" />
         </NavBlock>
+        </Authorized>
         <NavBlock
           highlightWhen={['data-explorer']}
           icon="graphline-2"
@@ -92,6 +98,10 @@ class SideNav extends PureComponent<Props> {
         >
           <NavHeader link={`${sourcePrefix}/dashboards`} title="Dashboards" />
         </NavBlock>
+        <Authorized
+          requiredRole={EDITOR_ROLE}
+          replaceWithIfNotUsingAuth={}
+          >
         <NavBlock
           highlightWhen={['alerts', 'alert-rules', 'tickscript']}
           icon="alerts"
@@ -106,6 +116,7 @@ class SideNav extends PureComponent<Props> {
             Alert History
           </NavListItem>
         </NavBlock>
+      </Authorized>
 
         <NavBlock
           highlightWhen={['logs']}
@@ -130,6 +141,18 @@ class SideNav extends PureComponent<Props> {
                 title="InfluxDB Admin"
               />
             </NavBlock>
+
+            <NavBlock
+              highlightWhen={['manage-sources', 'kapacitors']}
+              icon="wrench"
+              link={`${sourcePrefix}/manage-sources`}
+              location={location}
+            >
+              <NavHeader
+                link={`${sourcePrefix}/manage-sources`}
+                title="Configuration"
+              />
+            </NavBlock>
           }
         >
           <NavBlock
@@ -151,7 +174,6 @@ class SideNav extends PureComponent<Props> {
               InfluxDB
             </NavListItem>
           </NavBlock>
-        </Authorized>
         <NavBlock
           highlightWhen={['manage-sources', 'kapacitors']}
           icon="wrench"
@@ -163,6 +185,7 @@ class SideNav extends PureComponent<Props> {
             title="Configuration"
           />
         </NavBlock>
+        </Authorized>
         {isUsingAuth ? (
           <UserNavBlock
             logoutLink={logoutLink}


### PR DESCRIPTION
- Add a personalized text in the login page
- Set default page to /dashboards
- Place /dashboards as first option in the menu since it is now the default
- Remove /hosts, /logs and /config from the side navigation bar if the user role is different than admin.
- Requires Editor role for creating Alerting Rules
