### PR TITLE
[DM-18343] Enable markdown content in table cells

### DIFF
--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames'
 import {connect} from 'react-redux'
 import moment from 'moment'
 import {ColumnSizer, SizedColumnProps, AutoSizer} from 'react-virtualized'
+import Markdown from 'react-markdown'
 
 // Components
 import {MultiGrid, PropsMultiGrid} from 'src/shared/components/MultiGrid'
@@ -574,7 +575,7 @@ class TableGraph extends PureComponent<Props, State> {
         onMouseOver={this.handleHover}
         title={cellContents}
       >
-        {cellContents}
+        <Markdown source={cellContents}/>
       </div>
     )
   }


### PR DESCRIPTION
By default, ReactJS escapes the HTML to prevent XSS (Cross-site scripting). In this PR we use the `markdown-react` library as an alternative to safely insert HTML code in the table cells.